### PR TITLE
"(publish, get, check, remove) is not a function" - not as expected in docs and sight (9.0.3)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { remove, check, get, publish } = require('./src/methods.js');
+const {remove, check, get, publish} = require('./src/methods.js');
 const info = require('./src/misc/constants.js').info;
 
 module.exports = {remove, check, get, publish, info}

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const JSP = require('./src/methods.js');
+const { remove, check, get, publish } = require('./src/methods.js');
 const info = require('./src/misc/constants.js').info;
 
-module.exports = {JSP, info}
+module.exports = {remove, check, get, publish, info}

--- a/package.json
+++ b/package.json
@@ -2,8 +2,13 @@
   "name": "jspaste",
   "version": "9.0.1",
   "description": "JSPaste official API wrapper for NodeJS. Publish, get, and remove documents with ease.",
-  "author": "tnfAngel",
+  "main": "index.js",
   "license": "MIT",
+  "author": "tnfAngel",
+  "contributors": [
+    "Inetol <contact@inetol.net>",
+    "Aidak"
+  ],
   "keywords": [
     "JSPaste",
     "hastebin",
@@ -11,15 +16,19 @@
     "tnfAngel",
     "jspaste"
   ],
-  "main": "index.js",
-  "engines": {
-    "node": ">=14"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/tnfAngel/jspaste-api.git"
   },
+  "bugs": {
+    "url": "https://github.com/tnfAngel/jspaste-api/issues"
+  },
+  "homepage": "https://jspaste.tk",
   "dependencies": {
     "axios": "^0.24.0"
+  },
+  "engines": {
+    "node": ">=14.0.0",
+    "npm": ">=7.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jspaste",
-  "version": "9.0.2",
+  "version": "9.0.3",
   "description": "JSPaste official API wrapper for NodeJS. Publish, get, and remove documents with ease.",
   "main": "index.js",
   "license": "MIT",

--- a/src/methods.js
+++ b/src/methods.js
@@ -2,7 +2,7 @@
 
 const a = require('axios').default;
 const constants = require('./misc/constants.js').constants;
-const handler = require('./misc/errorHandler.js').ErrorHandler;
+const handler = require('./misc/handler.js').Handler;
 
 const invalid = ['INVALID_PARAMS_PROVIDED', '"Key" or "Secret" is invalid or missing in the parameters', 'No body provided for the document'];
 const request = ['ERROR_ON_REQUEST', 'An error occurred while making the request: '];

--- a/src/misc/handler.js
+++ b/src/misc/handler.js
@@ -1,6 +1,6 @@
 'use strict';
 
-class ErrorHandler {
+class Handler {
     /**
      * @param e Error code output
      * @param s Error text output
@@ -13,4 +13,4 @@ class ErrorHandler {
     };
 }
 
-module.exports = {ErrorHandler};
+module.exports = {Handler};


### PR DESCRIPTION
Forgot to export functions directly with the elimination of the class in methods file.

Expected:
```js
const JSP = require('jspaste');

JSP.publish('Hello world!').then(r => console.info(r));
```

Actual:
```js
const JSP = require('jspaste');

JSP.JSP.publish('Hello world!').then(r => console.info(r));
```