### PR TITLE
bad package.json

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-engine-strict = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jspaste",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "description": "Powerful library to easily interact with JSPaste API",
   "license": "BSD-3-Clause-Clear",
   "author": "tnfAngel",
@@ -14,15 +14,8 @@
     "url": "https://github.com/tnfAngel/jspaste-api/issues"
   },
   "type": "module",
-  "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs",
-      "types": "./dist/index.d.ts"
-    }
-  },
-  "main": ".dist/index.cjs",
-  "module": ".dist/index.js",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "files": [
     "dist"
   ],
@@ -32,7 +25,7 @@
     "prepublishOnly": "npm run test && npm run build",
     "test": "npm run build:check && jest --no-cache"
   },
-  "types": ".dist/index.d.ts",
+  "types": "./dist/index.d.ts",
   "dependencies": {
     "centra": "^2.6.0"
   },
@@ -55,9 +48,7 @@
     "tnfangel"
   ],
   "engines": {
-    "node": ">=16.13.0",
-    "pnpm": "use-npm-instead",
-    "yarn": "use-npm-instead"
+    "node": ">=16.13.0"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
En el "package.json" había opciones que estaban para pruebas y han pasado directamente a producción, el problema reside en que no te permitirá instalar el paquete con yarn o pnpm de ningún modo. Este parche arregla esto más otro pequeño bug con los entrypoints del programa.

cc @tnfAngel 